### PR TITLE
fix:图像识别的时候带透明度转为颜色透明度

### DIFF
--- a/src/fill.js
+++ b/src/fill.js
@@ -437,6 +437,22 @@ export function getShapeFill(node, isSvgMode, warpObj) {
   if (fillColor) {
     fillColor = `#${fillColor}`
 
+    // 检查透明度
+    const alpha = parseInt(getTextByPathList(node, ['p:spPr', 'a:solidFill', 'a:srgbClr', 'a:alpha', 'attrs', 'val'])) / 100000
+    if (!isNaN(alpha)) {
+      const color = tinycolor(fillColor)
+      color.setAlpha(alpha)
+      return color.toHex8String()
+    }
+
+    // 检查方案颜色的透明度
+    const schemeAlpha = parseInt(getTextByPathList(node, ['p:spPr', 'a:solidFill', 'a:schemeClr', 'a:alpha', 'attrs', 'val'])) / 100000
+    if (!isNaN(schemeAlpha)) {
+      const color = tinycolor(fillColor)
+      color.setAlpha(schemeAlpha)
+      return color.toHex8String()
+    }
+
     let lumMod = parseInt(getTextByPathList(node, ['p:spPr', 'a:solidFill', 'a:schemeClr', 'a:lumMod', 'attrs', 'val'])) / 100000
     let lumOff = parseInt(getTextByPathList(node, ['p:spPr', 'a:solidFill', 'a:schemeClr', 'a:lumOff', 'attrs', 'val'])) / 100000
     if (isNaN(lumMod)) lumMod = 1.0


### PR DESCRIPTION
我发现图形在给了透明度的时候没有识别到，修改getShapeFill的内容，让背景色带了透明度可优化这个问题